### PR TITLE
Dock registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+MAINNET_RPC_URL=""
+SEPOLIA_RPC_URL="https://rpc.sepolia.org"
+BASE_SEPOLIA_RPC_URL="https://sepolia.base.org"
+BASESCAN_API_KEY=""
+CREATE2SALT="""
+DEPLOYER=""
+PRIVATE_KEY="0x{YOUR_PRIVATE_KEY}"
+MNEMONIC=""

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    "solidity.packageDefaultDependenciesContractsDirectory": "src",
+    "solidity.packageDefaultDependenciesDirectory": "lib",
+    "editor.formatOnSave": true,
+    "[solidity]": {
+        "editor.defaultFormatter": "NomicFoundation.hardhat-solidity"
+    },
+    "[toml]": {
+        "editor.defaultFormatter": "tamasfe.even-better-toml"
+    },
+    "search.exclude": {
+        "**/node_modules": true
+    },
+    "solidity.formatter": "forge"
+}

--- a/Makefile
+++ b/Makefile
@@ -13,39 +13,52 @@ clean :; forge clean
 # See https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/coverage.sh
 tests-coverage :; ./coverage.sh
 
-# Deploy the {InvoiceModule} contracts deterministically on Base Sepolia 
-# See Sablier V2 deployments on Base Sepolia: https://docs.sablier.com/contracts/v2/deployments#base-sepolia
-# Update the {PRIVATE_KEY} .env variable with the deployer private key
-deploy-deterministic-base-sepolia-invoice-module: 
-					forge script script/DeployDeterministicInvoiceModule.s.sol:DeployDeterministicInvoiceModule $(CREATE2SALT) \
-					0xFE7fc0Bbde84C239C0aB89111D617dC7cc58049f 0xb8c724df3eC8f2Bf8fA808dF2cB5dbab22f3E68c 0x85E094B259718Be1AF0D8CbBD41dd7409c2200aa \
-					--sig "run(string,address,address,address)" --rpc-url base_sepolia --private-key $(PRIVATE_KEY) --etherscan-api-key $(BASESCAN_API_KEY) 
-					--broadcast --verify
-
-# Deploy the {InvoiceModule} contracts deterministically on Base 
-# See Sablier V2 deployments on Base Sepolia: https://docs.sablier.com/contracts/v2/deployments#base
-# Update the {PRIVATE_KEY} .env variable with the deployer private key
-deploy-deterministic-base-invoice-module: 
-					forge script script/DeployDeterministicInvoiceModule.s.sol:DeployDeterministicInvoiceModule $(CREATE2SALT) \
-					0x4CB16D4153123A74Bc724d161050959754f378D8 0xf4937657Ed8B3f3cB379Eed47b8818eE947BEb1e 0x85E094B259718Be1AF0D8CbBD41dd7409c2200aa \
-					--sig "run(string,address,address,address)" --rpc-url base_sepolia --private-key $(PRIVATE_KEY) --etherscan-api-key $(BASESCAN_API_KEY) 
+# Deploy the {InvoiceModule} contract deterministically
+# See Sablier V2 deployments: https://docs.sablier.com/contracts/v2/deployments
+#
+# Update the following configs before running the script:
+#	- {SABLIER_LOCKUP_LINEAR} with the according {SablierV2LockupLinear} deployment address
+#	- {SABLIER_LOCKUP_TRANCHED} with the according {SablierV2LockupTranched} deployment address
+#	- {BROKER_ADMIN} with the address of the account managing the Sablier V2 integration fee
+#	- {RPC_URL} with the network RPC used for deployment
+deploy-deterministic-invoice-module: 
+					forge script script/DeployDeterministicInvoiceModule.s.sol:DeployDeterministicInvoiceModule \
+					$(CREATE2SALT) {SABLIER_LOCKUP_LINEAR} {SABLIER_LOCKUP_TRANCHED} {BROKER_ADMIN} \
+					--sig "run(string,address,address,address)" --rpc-url {RPC_URL} --private-key $(PRIVATE_KEY) --etherscan-api-key $(ETHERSCAN_API_KEY) 
 					--broadcast --verify
 
 
-# Deploy a {Container} contract deterministically on Base 
-# Update the {PRIVATE_KEY} .env variable with the deployer private key
-deploy-deterministic-base-container: 
+# Deploy a {Container} contract deterministically 
+# Update the following configs before running the script:
+#	- {INITIAL_OWNER} with the address of the initial owner
+#	- {MODULE_KEEPER_ADDRESS} with the address of the {ModuleKeeper} deployment
+#	- {RPC_URL} with the network RPC used for deployment
+deploy-deterministic-container: 
 					forge script script/DeployDeterministicContainer.s.sol:DeployDeterministicContainer \
-					$(CREATE2SALT) 0x85E094B259718Be1AF0D8CbBD41dd7409c2200aa [] \
-					--sig "run(string,address,address[])" --rpc-url base_sepolia \
-					--private-key $(PRIVATE_KEY) --etherscan-api-key $(BASESCAN_API_KEY) \
+					$(CREATE2SALT) {INITIAL_OWNER} {MODULE_KEEPER_ADDRESS} [] \
+					--sig "run(string,address,address,address[])" --rpc-url {RPC_URL} \
+					--private-key $(PRIVATE_KEY) --etherscan-api-key $(ETHERSCAN_API_KEY) \
 					--broadcast --verify			
 
-# Deploy a {Container} contract on Base 
-# Update the {PRIVATE_KEY} .env variable with the deployer private key
-deploy-base-container: 
+# Deploy a {Container} contract
+# Update the following configs before running the script:
+#	- {INITIAL_OWNER} with the address of the initial owner
+#	- {MODULE_KEEPER_ADDRESS} with the address of the {ModuleKeeper} deployment
+#	- {RPC_URL} with the network RPC used for deployment
+deploy-container: 
 					forge script script/DeployContainer.s.sol:DeployContainer \
-					 0x85E094B259718Be1AF0D8CbBD41dd7409c2200aa [] \
-					--sig "run(address,address[])" --rpc-url base_sepolia \
-					--private-key $(PRIVATE_KEY) --etherscan-api-key $(BASESCAN_API_KEY) \
+					 {INITIAL_OWNER} {MODULE_KEEPER_ADDRESS} [] \
+					--sig "run(address,address,address[])" --rpc-url {RPC_URL} \
+					--private-key $(PRIVATE_KEY) --etherscan-api-key $(ETHERSCAN_API_KEY) \
 					--broadcast --verify	
+
+# Deploy the {ModuleKeeper} contract deterministically 
+# Update the following configs before running the script:
+#	- {INITIAL_OWNER} with the address of the initial owner
+#	- {RPC_URL} with the network RPC used for deployment
+deploy-deterministic-module-keeper:
+					forge script script/DeployDeterministicModuleKeeper.s.sol:DeployDeterministicModuleKeeper \
+					$(CREATE2SALT) {INITIAL_OWNER} \
+					--sig "run(string,address)" --rpc-url {RPC_URL} \
+					--private-key $(PRIVATE_KEY) --etherscan-api-key $(ETHERSCAN_API_KEY) \
+					--broadcast --verify

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+-include .env
+
+# Build contracts
+build :; forge build
+
+# Run tests
+run-tests :; forge test
+
+# Clean build contracts
+clean :; forge clean
+
+# Generate coverage stats using lcov and genhtml
+# See https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/coverage.sh
+tests-coverage :; ./coverage.sh
+
+# Deploy the {InvoiceModule} contracts deterministically on Base Sepolia 
+# See Sablier V2 deployments on Base Sepolia: https://docs.sablier.com/contracts/v2/deployments#base-sepolia
+# Update the {PRIVATE_KEY} .env variable with the deployer private key
+deploy-deterministic-base-sepolia-invoice-module: 
+					forge script script/DeployDeterministicInvoiceModule.s.sol:DeployDeterministicInvoiceModule $(CREATE2SALT) \
+					0xFE7fc0Bbde84C239C0aB89111D617dC7cc58049f 0xb8c724df3eC8f2Bf8fA808dF2cB5dbab22f3E68c 0x85E094B259718Be1AF0D8CbBD41dd7409c2200aa \
+					--sig "run(string,address,address,address)" --rpc-url base_sepolia --private-key $(PRIVATE_KEY) --etherscan-api-key $(BASESCAN_API_KEY) 
+					--broadcast --verify
+
+# Deploy the {InvoiceModule} contracts deterministically on Base 
+# See Sablier V2 deployments on Base Sepolia: https://docs.sablier.com/contracts/v2/deployments#base
+# Update the {PRIVATE_KEY} .env variable with the deployer private key
+deploy-deterministic-base-invoice-module: 
+					forge script script/DeployDeterministicInvoiceModule.s.sol:DeployDeterministicInvoiceModule $(CREATE2SALT) \
+					0x4CB16D4153123A74Bc724d161050959754f378D8 0xf4937657Ed8B3f3cB379Eed47b8818eE947BEb1e 0x85E094B259718Be1AF0D8CbBD41dd7409c2200aa \
+					--sig "run(string,address,address,address)" --rpc-url base_sepolia --private-key $(PRIVATE_KEY) --etherscan-api-key $(BASESCAN_API_KEY) 
+					--broadcast --verify
+
+
+# Deploy a {Container} contract deterministically on Base 
+# Update the {PRIVATE_KEY} .env variable with the deployer private key
+deploy-deterministic-base-container: 
+					forge script script/DeployDeterministicContainer.s.sol:DeployDeterministicContainer \
+					$(CREATE2SALT) 0x85E094B259718Be1AF0D8CbBD41dd7409c2200aa [] \
+					--sig "run(string,address,address[])" --rpc-url base_sepolia \
+					--private-key $(PRIVATE_KEY) --etherscan-api-key $(BASESCAN_API_KEY) \
+					--broadcast --verify			
+
+# Deploy a {Container} contract on Base 
+# Update the {PRIVATE_KEY} .env variable with the deployer private key
+deploy-base-container: 
+					forge script script/DeployContainer.s.sol:DeployContainer \
+					 0x85E094B259718Be1AF0D8CbBD41dd7409c2200aa [] \
+					--sig "run(address,address[])" --rpc-url base_sepolia \
+					--private-key $(PRIVATE_KEY) --etherscan-api-key $(BASESCAN_API_KEY) \
+					--broadcast --verify	

--- a/README.md
+++ b/README.md
@@ -8,8 +8,14 @@
     <a href="https://github.com/metadock/contracts/actions?query=workflow%3Atest">
         <img src="https://img.shields.io/github/actions/workflow/status/metadock/contracts/test.yml?branch=main&label=Tests" alt="Tests">
     </a>
-    <a href="#">
-        <img src="https://img.shields.io/twitter/follow/MetaDockApp?label=Follow" alt="Twitter Follow">
+     <a href="https://getfoundry.sh/">
+        <img src="https://img.shields.io/badge/Built%20with-Foundry-FFDB1C.svg" alt="Built with Foundry">
+    </a>
+    <a href="https://x.com/MetaDockApp">
+        <img src="https://img.shields.io/twitter/follow/MetaDockApp?label=Follow" alt="Follow on X">
+    </a>
+    <a href="https://discord.com/invite/6yPqGwQN">
+        <img src="https://dcbadge.limes.pink/api/server/6yPqGwQN?style=flat" alt="Join Discord">
     </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ the same time, a Container can execute arbitrary code on an unlimited number of 
 MetaDock protocol with a modular architecture, providing an opportunity to create an open market of Modules where
 external players can create and integrate their own use-cases into the protocol.
 
-A module must first be enabled through the `ModuleManager` before being made publicly available to MetaDock users.
-Currently, only the MetaDock team can enable or disable modules due to the high-security risks they present.
+A module must first be allowlisted through the `ModuleKeeper` before being made publicly available to MetaDock users.
+Currently, due to the high-security risks, only the MetaDock team can add modules to or remove them from the allowlist.
+
+Once a module is allowlisted, it can be enabled via the `enableModule()` method available on any `Container`.
 
 ### Invoice Module
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -15,4 +15,13 @@ quote_style = "double"
 tab_width = 4
 wrap_comments = false
 
+[rpc_endpoints]
+mainnet = "${MAINNET_RPC_URL}"
+sepolia = "${SEPOLIA_RPC_URL}"
+base_sepolia = "${BASE_SEPOLIA_RPC_URL}"
+
+[etherscan]
+sepolia = { key = "${ETHERSCAN_API_KEY}" }
+base_sepolia = { key = "${BASESCAN_API_KEY}" }
+
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/script/Base.s.sol
+++ b/script/Base.s.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.20;
+
+import { Script } from "forge-std/Script.sol";
+
+contract BaseScript is Script {
+    /// @dev Junk mnemonic seed phrase use as a fallback in case there is no mnemonic set in the `.env` file
+    string internal constant TEST_MNEMONIC = "test test test test test test test test test test test junk";
+
+    /// @dev Used to derive the deployer's address
+    string internal mnemonic;
+
+    /// @dev Stores the deployer address
+    address deployer;
+
+    constructor() {
+        address from = vm.envOr({ name: "DEPLOYER", defaultValue: address(0) });
+        if (from != address(0)) {
+            deployer = from;
+        } else {
+            mnemonic = vm.envOr({ name: "MNEMONIC", defaultValue: TEST_MNEMONIC });
+            (deployer, ) = deriveRememberKey(mnemonic, 0);
+        }
+    }
+
+    modifier broadcast() {
+        vm.startBroadcast(deployer);
+        _;
+        vm.stopBroadcast();
+    }
+}

--- a/script/DeployContainer.s.sol
+++ b/script/DeployContainer.s.sol
@@ -3,14 +3,16 @@ pragma solidity ^0.8.26;
 
 import { BaseScript } from "./Base.s.sol";
 import { Container } from "../src/Container.sol";
+import { ModuleKeeper } from "./../src/ModuleKeeper.sol";
 
 /// @notice Deploys an instance of {Container} and enables initial module(s)
 contract DeployContainer is BaseScript {
     function run(
         address initialOwner,
+        ModuleKeeper moduleKeeper,
         address[] memory initialModules
     ) public virtual broadcast returns (Container container) {
         // Ddeploy the {InvoiceModule} contracts
-        container = new Container(initialOwner, initialModules);
+        container = new Container(initialOwner, moduleKeeper, initialModules);
     }
 }

--- a/script/DeployContainer.s.sol
+++ b/script/DeployContainer.s.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.26;
+
+import { BaseScript } from "./Base.s.sol";
+import { Container } from "../src/Container.sol";
+
+/// @notice Deploys an instance of {Container} and enables initial module(s)
+contract DeployContainer is BaseScript {
+    function run(
+        address initialOwner,
+        address[] memory initialModules
+    ) public virtual broadcast returns (Container container) {
+        // Ddeploy the {InvoiceModule} contracts
+        container = new Container(initialOwner, initialModules);
+    }
+}

--- a/script/DeployDeterministicContainer.s.sol
+++ b/script/DeployDeterministicContainer.s.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.26;
 
 import { BaseScript } from "./Base.s.sol";
 import { Container } from "../src/Container.sol";
+import { ModuleKeeper } from "./../src/ModuleKeeper.sol";
 
 /// @notice Deploys at deterministic addresses across chains an instance of {Container} and enables initial module(s)
 /// @dev Reverts if any contract has already been deployed
@@ -12,11 +13,12 @@ contract DeployDeterministicContainer is BaseScript {
     function run(
         string memory create2Salt,
         address initialOwner,
+        ModuleKeeper moduleKeeper,
         address[] memory initialModules
     ) public virtual broadcast returns (Container container) {
         bytes32 salt = bytes32(abi.encodePacked(create2Salt));
 
         // Deterministically deploy a {Container} contract
-        container = new Container{ salt: salt }(initialOwner, initialModules);
+        container = new Container{ salt: salt }(initialOwner, moduleKeeper, initialModules);
     }
 }

--- a/script/DeployDeterministicContainer.s.sol
+++ b/script/DeployDeterministicContainer.s.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.26;
+
+import { BaseScript } from "./Base.s.sol";
+import { Container } from "../src/Container.sol";
+
+/// @notice Deploys at deterministic addresses across chains an instance of {Container} and enables initial module(s)
+/// @dev Reverts if any contract has already been deployed
+contract DeployDeterministicContainer is BaseScript {
+    /// @dev By using a salt, Forge will deploy the contract via a deterministic CREATE2 factory
+    /// https://book.getfoundry.sh/tutorials/create2-tutorial?highlight=deter#deterministic-deployment-using-create2
+    function run(
+        string memory create2Salt,
+        address initialOwner,
+        address[] memory initialModules
+    ) public virtual broadcast returns (Container container) {
+        bytes32 salt = bytes32(abi.encodePacked(create2Salt));
+
+        // Deterministically deploy a {Container} contract
+        container = new Container{ salt: salt }(initialOwner, initialModules);
+    }
+}

--- a/script/DeployDeterministicInvoiceModule.s.sol
+++ b/script/DeployDeterministicInvoiceModule.s.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.26;
+
+import { BaseScript } from "./Base.s.sol";
+import { InvoiceModule } from "../src/modules/invoice-module/InvoiceModule.sol";
+import { ISablierV2LockupLinear } from "@sablier/v2-core/src/interfaces/ISablierV2LockupLinear.sol";
+import { ISablierV2LockupTranched } from "@sablier/v2-core/src/interfaces/ISablierV2LockupTranched.sol";
+
+/// @notice Deploys and initializes the {InvoiceModule} contracts at deterministic addresses across chains
+/// @dev Reverts if any contract has already been deployed
+contract DeployDeterministicInvoiceModule is BaseScript {
+    /// @dev By using a salt, Forge will deploy the contract via a deterministic CREATE2 factory
+    /// https://book.getfoundry.sh/tutorials/create2-tutorial?highlight=deter#deterministic-deployment-using-create2
+    function run(
+        string memory create2Salt,
+        ISablierV2LockupLinear sablierLockupLinear,
+        ISablierV2LockupTranched sablierLockupTranched,
+        address brokerAdmin
+    ) public virtual broadcast returns (InvoiceModule invoiceModule) {
+        bytes32 salt = bytes32(abi.encodePacked(create2Salt));
+
+        // Deterministically deploy the {InvoiceModule} contracts
+        invoiceModule = new InvoiceModule{ salt: salt }(sablierLockupLinear, sablierLockupTranched, brokerAdmin);
+    }
+}

--- a/script/DeployDeterministicModuleKeeper.s.sol
+++ b/script/DeployDeterministicModuleKeeper.s.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.26;
+
+import { BaseScript } from "./Base.s.sol";
+import { ModuleKeeper } from "./../src/ModuleKeeper.sol";
+
+/// @notice Deploys at deterministic addresses across chains the {ModuleKeeper} contract
+/// @dev Reverts if any contract has already been deployed
+contract DeployDeterministicModuleKeeper is BaseScript {
+    /// @dev By using a salt, Forge will deploy the contract via a deterministic CREATE2 factory
+    /// https://book.getfoundry.sh/tutorials/create2-tutorial?highlight=deter#deterministic-deployment-using-create2
+    function run(
+        string memory create2Salt,
+        address initialOwner
+    ) public virtual broadcast returns (ModuleKeeper moduleKeeper) {
+        bytes32 salt = bytes32(abi.encodePacked(create2Salt));
+
+        // Deterministically deploy the {ModuleKeeper} contract
+        moduleKeeper = new ModuleKeeper{ salt: salt }(initialOwner);
+    }
+}

--- a/src/ModuleKeeper.sol
+++ b/src/ModuleKeeper.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.26;
+
+import { IModuleKeeper } from "./interfaces/IModuleKeeper.sol";
+import { Ownable } from "./abstracts/Ownable.sol";
+import { Errors } from "./libraries/Errors.sol";
+
+/// @title ModuleKeeper
+/// @notice See the documentation in {IModuleKeeper}
+contract ModuleKeeper is IModuleKeeper, Ownable {
+    /*//////////////////////////////////////////////////////////////////////////
+                                  PUBLIC STORAGE
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc IModuleKeeper
+    mapping(address module => bool) public override isAllowlisted;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                   CONSTRUCTOR
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Initializes the initial owner of the {ModuleKeeper}
+    constructor(address _initialOwner) Ownable(_initialOwner) { }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                NON-CONSTANT FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc IModuleKeeper
+    function addToAllowlist(address module) public onlyOwner {
+        // Check: the module has a valid non-zero code size
+        if (module.code.length == 0) {
+            revert Errors.InvalidZeroCodeModule();
+        }
+
+        // Effects: add the module to the allowlist
+        isAllowlisted[module] = true;
+
+        // Log the module allowlisting
+        emit ModuleAllowlisted(owner, module);
+    }
+
+    /// @inheritdoc IModuleKeeper
+    function removeFromAllowlist(address module) public onlyOwner {
+        // Effects: remove the module from the allowlist
+        isAllowlisted[module] = false;
+
+        // Log the module removal from the allowlist
+        emit ModuleRemovedFromAllowlist(owner, module);
+    }
+}

--- a/src/interfaces/IModuleKeeper.sol
+++ b/src/interfaces/IModuleKeeper.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.26;
+
+/// @title IModuleKeeper
+/// @notice Contract responsible for managing an allowlist-based mapping with "safe to use" {Module} contracts
+interface IModuleKeeper {
+    /*//////////////////////////////////////////////////////////////////////////
+                                       EVENTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Emitted when a new module is allowlisted
+    /// @param owner The address of the {ModuleKeeper} owner
+    /// @param module The address of the module to be allowlisted
+    event ModuleAllowlisted(address indexed owner, address indexed module);
+
+    /// @notice Emitted when a module is removed from the allowlist
+    /// @param owner The address of the {ModuleKeeper} owner
+    /// @param module The address of the module to be removed
+    event ModuleRemovedFromAllowlist(address indexed owner, address indexed module);
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                 CONSTANT FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Checks if the `module` module is allowlisted to be used by a {Container}
+    /// @param module The address of the module contract
+    function isAllowlisted(address module) external view returns (bool allowlisted);
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                NON-CONSTANT FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Adds the `module` module to the allowlist
+    /// @param module The address of the module to be allowlisted
+    function addToAllowlist(address module) external;
+
+    /// @notice Removes the `module` module from the allowlist
+    /// @param module The address of the module to remove
+    function removeFromAllowlist(address module) external;
+}

--- a/src/interfaces/IModuleManager.sol
+++ b/src/interfaces/IModuleManager.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.26;
 
+import { ModuleKeeper } from "./../ModuleKeeper.sol";
+
 /// @title IModuleManager
 /// @notice Contract that provides functionalities to manage multiple modules within a {Container} contract
 interface IModuleManager {
@@ -19,6 +21,9 @@ interface IModuleManager {
     /*//////////////////////////////////////////////////////////////////////////
                                  CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Returns the address of the {ModuleKeeper} contract
+    function moduleKeeper() external view returns (ModuleKeeper);
 
     /// @notice Checks whether the `module` module is enabled on the container
     function isModuleEnabled(address module) external view returns (bool isEnabled);

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -32,11 +32,18 @@ library Errors {
                                   MODULE-MANAGER
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Thrown when the requested module to be enabled is not a contract
-    error InvalidZeroCodeModule();
-
-    /// @notice Thrown when a container tries to execute a method on a non-enabled module
+    /// @notice Thrown when a {Container} tries to execute a method on a non-enabled module
     error ModuleNotEnabled();
+
+    /// @notice Thrown when an attempt is made to enable a non-allowlisted module on a {Container}
+    error ModuleNotAllowlisted();
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                  MODULE-KEEPER
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Thrown when the requested module to be allowlisted is not a valid non-zero code size contract
+    error InvalidZeroCodeModule();
 
     /*//////////////////////////////////////////////////////////////////////////
                                       OWNABLE

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -28,18 +28,12 @@ abstract contract Integration_Test is Base_Test {
         // Deploy the {InvoiceModule} modul
         deployInvoiceModule();
 
-        // Make Eve the default caller to deploy a new {Container} contract
-        vm.startPrank({ msgSender: users.eve });
-
         // Setup the initial {InvoiceModule} module to be initialized on the {Container}
         address[] memory modules = new address[](1);
         modules[0] = address(invoiceModule);
 
         // Deploy the {Container} contract with the {InvoiceModule} enabled by default
-        container = deployContainer({ owner: users.eve, initialModules: modules });
-
-        // Stop the prank to be able to start a different one in the test suite
-        vm.stopPrank();
+        container = deployContainer({ _owner: users.eve, _moduleKeeper: moduleKeeper, _initialModules: modules });
 
         // Label the test contracts so we can easily track them
         vm.label({ account: address(invoiceModule), newLabel: "InvoiceModule" });
@@ -54,10 +48,8 @@ abstract contract Integration_Test is Base_Test {
     /// @dev Deploys the {InvoiceModule} module by initializing the Sablier v2-required contracts first
     function deployInvoiceModule() internal {
         mockNFTDescriptor = new NFTDescriptorMock();
-        sablierV2LockupLinear = new SablierV2LockupLinear({
-            initialAdmin: users.admin,
-            initialNFTDescriptor: mockNFTDescriptor
-        });
+        sablierV2LockupLinear =
+            new SablierV2LockupLinear({ initialAdmin: users.admin, initialNFTDescriptor: mockNFTDescriptor });
         sablierV2LockupTranched = new SablierV2LockupTranched({
             initialAdmin: users.admin,
             initialNFTDescriptor: mockNFTDescriptor,

--- a/test/unit/concrete/container/Container.t.sol
+++ b/test/unit/concrete/container/Container.t.sol
@@ -10,6 +10,6 @@ contract Container_Unit_Concrete_Test is Base_Test {
         address[] memory modules = new address[](1);
         modules[0] = address(mockModule);
 
-        container = deployContainer({ owner: users.eve, initialModules: modules });
+        container = deployContainer({ _owner: users.eve, _moduleKeeper: moduleKeeper, _initialModules: modules });
     }
 }

--- a/test/unit/concrete/container/disable-module/disableModule.t.sol
+++ b/test/unit/concrete/container/disable-module/disableModule.t.sol
@@ -29,9 +29,6 @@ contract DisableModule_Unit_Concrete_Test is Container_Unit_Concrete_Test {
     }
 
     modifier givenModuleEnabled() {
-        // Create a new mock module
-        MockModule mockModule = new MockModule();
-
         // Enable the {MockModule} first
         container.enableModule({ module: address(mockModule) });
         _;

--- a/test/unit/concrete/container/enable-module/enableModule.t.sol
+++ b/test/unit/concrete/container/enable-module/enableModule.t.sol
@@ -28,9 +28,9 @@ contract EnableModule_Unit_Concrete_Test is Container_Unit_Concrete_Test {
         _;
     }
 
-    function test_RevertWhen_InvalidZeroCodeModule() external whenCallerOwner {
-        // Expect the next call to revert with the {InvalidZeroCodeModule}
-        vm.expectRevert(Errors.InvalidZeroCodeModule.selector);
+    function test_RevertWhen_ModuleNotAllowlisted() external whenCallerOwner {
+        // Expect the next call to revert with the {ModuleNotAllowlisted}
+        vm.expectRevert(Errors.ModuleNotAllowlisted.selector);
 
         // Run the test
         container.enableModule({ module: address(0x1) });
@@ -41,9 +41,6 @@ contract EnableModule_Unit_Concrete_Test is Container_Unit_Concrete_Test {
     }
 
     function test_EnableModule() external whenCallerOwner whenNonZeroCodeModule {
-        // Create a new mock module
-        MockModule mockModule = new MockModule();
-
         // Expect the {ModuleEnabled} to be emitted
         vm.expectEmit();
         emit Events.ModuleEnabled({ module: address(mockModule), owner: users.eve });

--- a/test/unit/concrete/container/enable-module/enableModule.tree
+++ b/test/unit/concrete/container/enable-module/enableModule.tree
@@ -2,8 +2,8 @@ enableModule.t.sol
 ├── when the caller IS NOT the container owner
 │   └── it should revert with the {Unauthorized} error
 └── when the caller IS the container owner
-    ├── when the module has a zero-code size
-    │   └── it should revert with the {InvalidZeroCodeModule} error
-    └── when the module has a non-zero code size
+    ├── when the module IS NOT allowlisted
+    │   └── it should revert with the {ModuleNotAllowlisted} error
+    └── when the module IS allowlisted
             ├── it should mark the module as enabled
             └── it should emit a {ModuleEnabled} event

--- a/test/unit/concrete/module-keeper/ModuleKeeper.t.sol
+++ b/test/unit/concrete/module-keeper/ModuleKeeper.t.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+import { Base_Test } from "../../../Base.t.sol";
+
+contract ModuleKeeper_Unit_Concrete_Test is Base_Test {
+    function setUp() public virtual override {
+        Base_Test.setUp();
+    }
+}

--- a/test/unit/concrete/module-keeper/add-to-allowlist/addToAllowlist.sol
+++ b/test/unit/concrete/module-keeper/add-to-allowlist/addToAllowlist.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+import { ModuleKeeper_Unit_Concrete_Test } from "../ModuleKeeper.t.sol";
+import { MockModule } from "../../../../mocks/MockModule.sol";
+import { Errors } from "../../../../utils/Errors.sol";
+import { Events } from "../../../../utils/Events.sol";
+
+contract AddToAllowlist_Unit_Concrete_Test is ModuleKeeper_Unit_Concrete_Test {
+    function setUp() public virtual override {
+        ModuleKeeper_Unit_Concrete_Test.setUp();
+    }
+
+    function test_RevertWhen_CallerNotOwner() external {
+        // Make Bob the caller for this test suite who is not the owner of the container
+        vm.startPrank({ msgSender: users.bob });
+
+        // Expect the next call to revert with the {Unauthorized} error
+        vm.expectRevert(Errors.Unauthorized.selector);
+
+        // Run the test
+        moduleKeeper.addToAllowlist({ module: address(0x1) });
+    }
+
+    modifier whenCallerOwner() {
+        // Make Admin the caller for the next test suite
+        vm.startPrank({ msgSender: users.admin });
+        _;
+    }
+
+    function test_RevertWhen_InvalidZeroCodeModule() external whenCallerOwner {
+        // Expect the next call to revert with the {InvalidZeroCodeModule} error
+        vm.expectRevert(Errors.InvalidZeroCodeModule.selector);
+
+        // Run the test by trying to execute a module at `0x0000000000000000000000000000000000000001` address
+        moduleKeeper.addToAllowlist({ module: address(0x1) });
+    }
+
+    modifier whenValidNonZeroCodeModule() {
+        _;
+    }
+
+    function test_AddToAllowlist() external whenCallerOwner whenValidNonZeroCodeModule {
+        // Deploy a new {MockModule} contract to be allowlisted
+        MockModule moduleToAllowlist = new MockModule();
+
+        // Expect the {ModuleAllowlisted} event to be emitted
+        vm.expectEmit();
+        emit Events.ModuleAllowlisted({ owner: users.admin, module: address(moduleToAllowlist) });
+
+        // Run the test
+        moduleKeeper.addToAllowlist({ module: address(moduleToAllowlist) });
+
+        // Assert the actual and expected allowlist state of the module
+        bool actualIsAllowlisted = moduleKeeper.isAllowlisted({ module: address(moduleToAllowlist) });
+        assertTrue(actualIsAllowlisted);
+    }
+}

--- a/test/unit/concrete/module-keeper/add-to-allowlist/addToAllowlist.tree
+++ b/test/unit/concrete/module-keeper/add-to-allowlist/addToAllowlist.tree
@@ -1,0 +1,9 @@
+addToAllowlist.t.sol
+├── when the caller IS NOT the {ModuleKeeper} owner
+│   └── it should revert with the {Unauthorized} error
+└── when the caller IS the {ModuleKeeper} owner
+    ├── when the module has an invalid zero-code size
+    │   └── it should revert with the {InvalidZeroCodeModule} error
+    └── when the module has a valid non-zero code size
+        ├── it should mark the module as allowed
+        └── it should emit a {ModuleAllowlisted} event

--- a/test/unit/concrete/module-keeper/remove-from-allowlist/removeFromAllowlist.sol
+++ b/test/unit/concrete/module-keeper/remove-from-allowlist/removeFromAllowlist.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+import { ModuleKeeper_Unit_Concrete_Test } from "../ModuleKeeper.t.sol";
+import { MockModule } from "../../../../mocks/MockModule.sol";
+import { Errors } from "../../../../utils/Errors.sol";
+import { Events } from "../../../../utils/Events.sol";
+
+contract RemoveFromAllowlist_Unit_Concrete_Test is ModuleKeeper_Unit_Concrete_Test {
+    function setUp() public virtual override {
+        ModuleKeeper_Unit_Concrete_Test.setUp();
+    }
+
+    function test_RevertWhen_CallerNotOwner() external {
+        // Make Bob the caller for this test suite who is not the owner of the container
+        vm.startPrank({ msgSender: users.bob });
+
+        // Expect the next call to revert with the {Unauthorized} error
+        vm.expectRevert(Errors.Unauthorized.selector);
+
+        // Run the test
+        moduleKeeper.removeFromAllowlist({ module: address(0x1) });
+    }
+
+    modifier whenCallerOwner() {
+        // Make Admin the caller for the next test suite
+        vm.startPrank({ msgSender: users.admin });
+        _;
+    }
+
+    modifier givenModuleAllowlisted() {
+        _;
+    }
+
+    function test_AddToAllowlist() external whenCallerOwner givenModuleAllowlisted {
+        // Expect the {ModuleRemovedFromAllowlist} event to be emitted
+        vm.expectEmit();
+        emit Events.ModuleRemovedFromAllowlist({ owner: users.admin, module: address(mockModule) });
+
+        // Run the test
+        moduleKeeper.removeFromAllowlist({ module: address(mockModule) });
+
+        // Assert the actual and expected allowlist state of the module
+        bool actualIsAllowlisted = moduleKeeper.isAllowlisted({ module: address(mockModule) });
+        assertFalse(actualIsAllowlisted);
+    }
+}

--- a/test/unit/concrete/module-keeper/remove-from-allowlist/removeFromAllowlist.tree
+++ b/test/unit/concrete/module-keeper/remove-from-allowlist/removeFromAllowlist.tree
@@ -1,0 +1,7 @@
+removeFromAllowlist.t.sol
+├── when the caller IS NOT the {ModuleKeeper} owner
+│   └── it should revert with the {Unauthorized} error
+└── when the caller IS the {ModuleKeeper} owner
+    └── given module allowlisted
+        ├── it should mark the module as allowed
+        └── it should emit a {ModuleAllowlisted} event

--- a/test/utils/Errors.sol
+++ b/test/utils/Errors.sol
@@ -30,11 +30,18 @@ library Errors {
                                   MODULE-MANAGER
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Thrown when the requested module to be enabled is not a contract
-    error InvalidZeroCodeModule();
-
-    /// @notice Thrown when a container tries to execute a method on a non-enabled module
+    /// @notice Thrown when a {Container} tries to execute a method on a non-enabled module
     error ModuleNotEnabled();
+
+    /// @notice Thrown when an attempt is made to enable a non-allowlisted module on a {Container}
+    error ModuleNotAllowlisted();
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                  MODULE-KEEPER
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Thrown when the requested module to be allowlisted is not a valid non-zero code size contract
+    error InvalidZeroCodeModule();
 
     /*//////////////////////////////////////////////////////////////////////////
                                     INVOICE-MODULE

--- a/test/utils/Events.sol
+++ b/test/utils/Events.sol
@@ -77,4 +77,18 @@ abstract contract Events {
     /// @param oldOwner The address of the previous owner
     /// @param newOwner The address of the new owner
     event OwnershipTransferred(address indexed oldOwner, address newOwner);
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                  MODULE-KEEPER
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Emitted when a new module is allowlisted
+    /// @param owner The address of the {ModuleKeeper} owner
+    /// @param module The address of the module to be allowlisted
+    event ModuleAllowlisted(address indexed owner, address indexed module);
+
+    /// @notice Emitted when a module is removed from the allowlist
+    /// @param owner The address of the {ModuleKeeper} owner
+    /// @param module The address of the module to be removed
+    event ModuleRemovedFromAllowlist(address indexed owner, address indexed module);
 }


### PR DESCRIPTION
As discussed with @V1d0r and team, we're going to move the `Dock` creation process on-chain. This allows a MetaDock user to create and manage `Container`s through a single access point.

`DockRegistry` follows the Factory Pattern, allowing users to deploy multiple `Container`s and manage their ownership. 