### PR TITLE
Make `DockRegistry` UUPS upgradeable

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,10 @@ libs = ["lib"]
 optimizer = true
 optimizer_runs = 1000
 gas_reports = ["ModuleKeeper", "DockRegistry", "Container"]
+ffi = true
+ast = true
+build_info = true
+extra_output = ["storageLayout"]
 
 [fmt]
 bracket_spacing = true

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,5 @@
 @openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
+@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
 @sablier/v2-core/=lib/v2-core/
 @prb/math/=lib/prb-math/
 @nomad-xyz/excessively-safe-call/=lib/nomad-xyz/excessively-safe-call/

--- a/script/DeployDeterministicDockRegistry.s.sol
+++ b/script/DeployDeterministicDockRegistry.s.sol
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.26;
 
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { Options } from "./../lib/openzeppelin-foundry-upgrades/src/Options.sol";
+import { Core } from "./../lib/openzeppelin-foundry-upgrades/src/internal/Core.sol";
+
 import { BaseScript } from "./Base.s.sol";
 import { DockRegistry } from "./../src/DockRegistry.sol";
 import { ModuleKeeper } from "./../src/ModuleKeeper.sol";
@@ -18,6 +22,25 @@ contract DeployDeterministicDockRegistry is BaseScript {
         bytes32 salt = bytes32(abi.encodePacked(create2Salt));
 
         // Deterministically deploy a {DockRegistry} contract
-        dockRegistry = new DockRegistry{ salt: salt }(initialOwner, moduleKeeper);
+        dockRegistry = DockRegistry(
+            deployDetermisticUUPSProxy(
+                salt, "DockRegistry.sol", abi.encodeCall(DockRegistry.initialize, (initialOwner, moduleKeeper))
+            )
+        );
+    }
+
+    /// @dev Deploys a UUPS proxy at deterministic addresses across chains based on a provided salt
+    /// @param salt Salt to use for deterministic deployment
+    /// @param contractName The name of the implementation contract
+    /// @param initializerData The ABI encoded call to be made to the initialize method
+    function deployDetermisticUUPSProxy(
+        bytes32 salt,
+        string memory contractName,
+        bytes memory initializerData
+    ) internal returns (address) {
+        Options memory opts;
+        address impl = Core.deployImplementation(contractName, opts);
+
+        return address(new ERC1967Proxy{ salt: salt }(impl, initializerData));
     }
 }

--- a/src/interfaces/IDockRegistry.sol
+++ b/src/interfaces/IDockRegistry.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.26;
 
-import { IContainer } from "./IContainer.sol";
 import { Container } from "./../Container.sol";
 import { IModuleKeeper } from "./IModuleKeeper.sol";
 import { ModuleKeeper } from "./../ModuleKeeper.sol";

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -11,6 +11,7 @@ import { MockBadReceiver } from "./mocks/MockBadReceiver.sol";
 import { Container } from "./../src/Container.sol";
 import { ModuleKeeper } from "./../src/ModuleKeeper.sol";
 import { DockRegistry } from "./../src/DockRegistry.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 abstract contract Base_Test is Test, Events {
     /*//////////////////////////////////////////////////////////////////////////
@@ -50,7 +51,11 @@ abstract contract Base_Test is Test, Events {
 
         // Deploy test contracts
         moduleKeeper = new ModuleKeeper({ _initialOwner: users.admin });
-        dockRegistry = new DockRegistry({ _initialOwner: users.admin, _moduleKeeper: moduleKeeper });
+
+        address implementation = address(new DockRegistry());
+        bytes memory data = abi.encodeWithSelector(DockRegistry.initialize.selector, users.admin, moduleKeeper);
+        dockRegistry = DockRegistry(address(new ERC1967Proxy(implementation, data)));
+
         mockModule = new MockModule();
         mockNonCompliantContainer = new MockNonCompliantContainer({ _owner: users.admin });
         mockBadReceiver = new MockBadReceiver();


### PR DESCRIPTION
As per `DockRegistry` implementation PR https://github.com/metadock/contracts/pull/18, we need to consider the ability to enhance the registry capabilities in the future.

Right now, `DockRegistry` is responsible for creating multiple docks and orchestrating `Container`s deployment. In addition, it is also in charge of allowing either the dock or `Container` owner to transfer their ownership to another address (be it EOA or multisig). 

Apart from this, since all `Container`s must do an external call to the `DockRegistry` to get the current owner (due to the `onlyOwner` modifier - see [this](https://github.com/metadock/contracts/blob/feat/upgradeable-dock-registry/src/Container.sol#L38-L42), we've decided to also store the address of the `ModuleKeeper` inside it. This allows the `DockRegistry` to truly act as the single source of truth in the MetaDock ecosystem.

With this in mind, we should prepare for any other management contract that might be implemented in the future and must be orchestrated through the `DockRegistry`. Therefore,  we've decided to make the registry upgradeable through the UUPS proxy pattern. By using this approach, we have the ability to renounce the upgradeability at any point in time due to the UUPS nature (when the protocol is stable and no more extra core features might be added). 

task: [28994cdf30964c90b34f17d7869ed085](https://www.notion.so/Engineering-5f9fef0992d1458ba279115e54c11405?p=28994cdf30964c90b34f17d7869ed085)
